### PR TITLE
Sped up the verification

### DIFF
--- a/gotains.go
+++ b/gotains.go
@@ -26,12 +26,12 @@ func Contains(slc interface{}, verItems ...interface{}) (bool, error) {
 		for _, v := range verItems {
 			if v == r {
 				checks++
+				if checks == itensToCheck {
+					return true, nil
+				}
 			}
 		}
 	}
 
-	if checks == itensToCheck {
-		return true, nil
-	}
 	return false, nil
 }

--- a/gotains.go
+++ b/gotains.go
@@ -22,8 +22,8 @@ func Contains(slc interface{}, verItems ...interface{}) (bool, error) {
 
 	itensToCheck := len(verItems)
 	checks := 0
-	for _, v := range verItems {
-		for _, r := range ret {
+	for _, r := range ret {
+		for _, v := range verItems {
 			if v == r {
 				checks++
 			}


### PR DESCRIPTION
This PR represents a simple change to speed up the `Contains` function.

**Rationale**:
By only traversing the (supposedly bigger) source array once and then checking the (supposedly smaller) `verItems` we avoid traversing the source array often. Also we check whether we've found the item every time we increment the counter so that if the searched for items are at the beginning of the array we don't have to traverse the whole thing.

Cheers
